### PR TITLE
Fix/multi server

### DIFF
--- a/data/src/client.rs
+++ b/data/src/client.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, fmt};
+use std::collections::BTreeMap;
+use std::fmt;
 
 use irc::client::Client;
 use irc::proto::Command;
@@ -60,7 +61,7 @@ impl Connection {
 }
 
 #[derive(Debug, Default)]
-pub struct Map(HashMap<Server, State>);
+pub struct Map(BTreeMap<Server, State>);
 
 impl Map {
     pub fn disconnected(&mut self, server: Server) {
@@ -111,11 +112,11 @@ impl Map {
             .unwrap_or_default()
     }
 
-    pub fn get_channels(&self) -> HashMap<Server, Vec<String>> {
-        let mut hashmap = HashMap::new();
+    pub fn get_channels(&self) -> BTreeMap<Server, Vec<String>> {
+        let mut map = BTreeMap::new();
 
         for (server, _) in self.0.iter() {
-            hashmap.insert(
+            map.insert(
                 server.clone(),
                 self.connection(server)
                     .map(|connection| connection.channels())
@@ -123,7 +124,7 @@ impl Map {
             );
         }
 
-        hashmap
+        map
     }
 
     pub fn get_channel_messages(&self, server: &Server, channel: &str) -> Vec<&Message> {

--- a/data/src/server.rs
+++ b/data/src/server.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Server(String);
 
 impl From<String> for Server {

--- a/data/src/stream.rs
+++ b/data/src/stream.rs
@@ -81,9 +81,9 @@ pub fn run() -> BoxStream<'static, Result> {
             } => loop {
                 let input = {
                     let mut select = stream::select(
-                        stream::select_all(servers.iter_mut().map(|server| &mut server.stream))
-                            .enumerate()
-                            .map(|(idx, result)| Input::IrcMessage(idx, result)),
+                        stream::select_all(servers.iter_mut().enumerate().map(|(idx, server)| {
+                            (&mut server.stream).map(move |result| Input::IrcMessage(idx, result))
+                        })),
                         receiver.recv().map(Input::Message).into_stream().boxed(),
                     );
 


### PR DESCRIPTION
Fixes a couple bugs I noticed when testing a multiple server config:

- Server / channel names would jump around due to hashmap iteration not being order stable. BTreeMap fixes this.
- Stream bug that mapped all incoming messages against the first server setup.