### PR TITLE
Unfocus on single ESC press

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,22 @@ impl Application for Halloy {
     fn subscription(&self) -> Subscription<Message> {
         Subscription::batch(vec![
             client::run().map(Message::Stream),
-            subscription::events().map(Message::Event),
+            subscription::events_with(filtered_events),
         ])
+    }
+}
+
+// Always capture ESC to unfocus pane right away
+fn filtered_events(event: iced::Event, status: iced::event::Status) -> Option<Message> {
+    use iced::event;
+
+    if let iced::Event::Keyboard(keyboard::Event::KeyPressed {
+        key_code: keyboard::KeyCode::Escape,
+        ..
+    }) = &event
+    {
+        Some(Message::Event(event))
+    } else {
+        matches!(status, event::Status::Ignored).then_some(Message::Event(event))
     }
 }


### PR DESCRIPTION
This fixes the issue where it takes 2 presses of ESC to unfocus a buffer since text input captures the first ESC press to unfocus itself. It feels better to unfocus the buffer on a single press (for now).